### PR TITLE
feat: Implement Kafka-based user registration notification service

### DIFF
--- a/USER_SERVICE/docker-compose.yml
+++ b/USER_SERVICE/docker-compose.yml
@@ -1,0 +1,70 @@
+#version: '2.1'
+services:
+  zoo1:
+    image: confluentinc/cp-zookeeper:7.3.2
+    hostname: zoo1
+    container_name: zoo1
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_SERVERS: zoo1:2888:3888
+
+  kafka1:
+    image: confluentinc/cp-kafka:7.3.2
+    hostname: kafka1
+    container_name: kafka1
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka1:19092,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9092,DOCKER://host.docker.internal:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181"
+      KAFKA_BROKER_ID: 1
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.authorizer.AclAuthorizer
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+    depends_on:
+      - zoo1
+
+  kafka2:
+    image: confluentinc/cp-kafka:7.3.2
+    hostname: kafka2
+    container_name: kafka2
+    ports:
+      - "9093:9093"
+      - "29093:29093"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka2:19093,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9093,DOCKER://host.docker.internal:29093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181"
+      KAFKA_BROKER_ID: 2
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.authorizer.AclAuthorizer
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+    depends_on:
+      - zoo1
+
+
+  kafka3:
+    image: confluentinc/cp-kafka:7.3.2
+    hostname: kafka3
+    container_name: kafka3
+    ports:
+      - "9094:9094"
+      - "29094:29094"
+    environment:
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka3:19094,EXTERNAL://${DOCKER_HOST_IP:-127.0.0.1}:9094,DOCKER://host.docker.internal:29094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,DOCKER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181"
+      KAFKA_BROKER_ID: 3
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.authorizer.AclAuthorizer
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+    depends_on:
+      - zoo1

--- a/USER_SERVICE/pom.xml
+++ b/USER_SERVICE/pom.xml
@@ -75,6 +75,20 @@
             <artifactId>json-patch</artifactId>
             <version>1.13</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-docker-compose</artifactId>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/USER_SERVICE/src/main/java/pl/dk/user_service/kafka/KafkaConfig.java
+++ b/USER_SERVICE/src/main/java/pl/dk/user_service/kafka/KafkaConfig.java
@@ -1,0 +1,21 @@
+package pl.dk.user_service.kafka;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+import static pl.dk.user_service.kafka.KafkaConstants.TOPIC_REGISTRATION;
+
+@Configuration
+class KafkaConfig {
+
+    @Bean
+    public NewTopic registrationEvents() {
+        return TopicBuilder.name(TOPIC_REGISTRATION)
+                .partitions(3)
+                .replicas(3)
+                .build();
+    }
+
+}

--- a/USER_SERVICE/src/main/java/pl/dk/user_service/kafka/KafkaConstants.java
+++ b/USER_SERVICE/src/main/java/pl/dk/user_service/kafka/KafkaConstants.java
@@ -1,0 +1,7 @@
+package pl.dk.user_service.kafka;
+
+public class KafkaConstants {
+
+    public static final String TOPIC_REGISTRATION = "user-service-registration-events";
+    public static final String USER_DTO_TRUSTED_PACKAGE = "pl.dk.user_service.user.dto";
+}

--- a/USER_SERVICE/src/main/java/pl/dk/user_service/notification/NotificationService.java
+++ b/USER_SERVICE/src/main/java/pl/dk/user_service/notification/NotificationService.java
@@ -1,0 +1,9 @@
+package pl.dk.user_service.notification;
+
+import pl.dk.user_service.user.dto.UserDto;
+
+public interface NotificationService {
+
+    void sendToRegistrationTopic(UserDto result);
+
+}

--- a/USER_SERVICE/src/main/java/pl/dk/user_service/user/NotificationServiceKafkaImpl.java
+++ b/USER_SERVICE/src/main/java/pl/dk/user_service/user/NotificationServiceKafkaImpl.java
@@ -1,0 +1,44 @@
+package pl.dk.user_service.user;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+import pl.dk.user_service.notification.NotificationService;
+import pl.dk.user_service.user.dto.UserDto;
+
+import java.util.concurrent.CompletableFuture;
+
+import static pl.dk.user_service.kafka.KafkaConstants.TOPIC_REGISTRATION;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+class NotificationServiceKafkaImpl implements NotificationService {
+
+    private final KafkaTemplate<String, UserDto> kafkaTemplate;
+
+    @Override
+    public void sendToRegistrationTopic(UserDto result) {
+        CompletableFuture<SendResult<String, UserDto>> sendResultCompletableFuture = kafkaTemplate.send(TOPIC_REGISTRATION, result.userId(), result)
+                .whenComplete((sendResult, throwable) -> {
+                    if (throwable != null) {
+                        handleFailure(throwable);
+                    } else {
+                        handleSuccess(result, sendResult);
+                    }
+                });
+    }
+
+    private void handleSuccess(UserDto result, SendResult<String, UserDto> sendResult) {
+        log.info("Message sent successfully for the key: {} and the value: {}, partition is {}",
+                result.userId(), result, sendResult.getRecordMetadata().partition());
+    }
+
+    private void handleFailure(Throwable throwable) {
+        log.error("Error sending the message and the exception is {} ", throwable.getMessage());
+    }
+
+}
+

--- a/USER_SERVICE/src/main/java/pl/dk/user_service/user/UserServiceImpl.java
+++ b/USER_SERVICE/src/main/java/pl/dk/user_service/user/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package pl.dk.user_service.user;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,6 +11,7 @@ import com.github.fge.jsonpatch.JsonPatchException;
 import com.github.fge.jsonpatch.mergepatch.JsonMergePatch;
 
 import lombok.RequiredArgsConstructor;
+import pl.dk.user_service.notification.NotificationService;
 import pl.dk.user_service.user.dto.SaveUserDto;
 
 import pl.dk.user_service.user.dto.UserDto;
@@ -20,10 +22,13 @@ import pl.dk.user_service.user.repositoryDto.EmailPhoneDto;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
+    private final NotificationService notificationService;
+
 
     @Override
     @Transactional
@@ -40,8 +45,9 @@ class UserServiceImpl implements UserService {
 
         User userToSave = UserDtoMapper.map(saveUserDto);
         User savedUser = userRepository.save(userToSave);
-        return UserDtoMapper.map(savedUser);
-
+        UserDto result = UserDtoMapper.map(savedUser);
+        notificationService.sendToRegistrationTopic(result);
+        return result;
     }
 
     private String checkRegisterConditions(EmailPhoneDto emailPhone, String userEmail, String phone) {
@@ -58,7 +64,6 @@ class UserServiceImpl implements UserService {
         } else {
             result = "email";
         }
-
         return result;
     }
 

--- a/USER_SERVICE/src/main/resources/application-dev.yml
+++ b/USER_SERVICE/src/main/resources/application-dev.yml
@@ -8,7 +8,16 @@ spring:
   datasource:
     url: jdbc:h2:mem:test
     username: sa
-    password: 
+    password:
+
+  kafka:
+    producer:
+      bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        retries: 3
+        retry-backoff-ms: 5000
 
   jpa:
     hibernate:
@@ -30,6 +39,15 @@ spring:
     clean-disabled: false
     enabled: true
     execute-in-transaction: true
+
+  docker:
+    compose:
+      stop:
+        command: down
+        arguments:
+          - --remove-orphans
+          - -v
+      file: USER_SERVICE/docker-compose.yml
 
 logging:
   level:

--- a/USER_SERVICE/src/main/resources/application.yml
+++ b/USER_SERVICE/src/main/resources/application.yml
@@ -1,5 +1,5 @@
-spring: 
-    application:
-        name: USER_SERVICE
-    profiles:
-        default: dev
+spring:
+  application:
+    name: USER_SERVICE
+  profiles:
+    default: dev

--- a/USER_SERVICE/src/test/java/pl/dk/user_service/user/UserControllerTest.java
+++ b/USER_SERVICE/src/test/java/pl/dk/user_service/user/UserControllerTest.java
@@ -1,25 +1,70 @@
 package pl.dk.user_service.user;
 
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import pl.dk.user_service.kafka.KafkaConstants;
+import pl.dk.user_service.user.dto.UserDto;
 
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.LOCATION;
 import static org.springframework.http.HttpStatus.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static pl.dk.user_service.kafka.KafkaConstants.USER_DTO_TRUSTED_PACKAGE;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
+@EmbeddedKafka(topics = KafkaConstants.TOPIC_REGISTRATION)
+@DirtiesContext
+@TestPropertySource(properties = {"spring.kafka.producer.bootstrap-servers=${spring.embedded.kafka.brokers}",
+        "spring.kafka.admin.properties.bootstrap.servers=${spring.embedded.kafka.brokers}"})
 public class UserControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
+
+    private Consumer<String, UserDto> consumer;
+
+    @BeforeEach
+    void setUp() {
+        Map<String, Object> configs = KafkaTestUtils.consumerProps("group1", "true", embeddedKafkaBroker);
+        configs.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+        JsonDeserializer<UserDto> userDtoJsonDeserializer = new JsonDeserializer<>();
+        userDtoJsonDeserializer.addTrustedPackages(USER_DTO_TRUSTED_PACKAGE);
+        consumer = new DefaultKafkaConsumerFactory<>(configs, new StringDeserializer(), userDtoJsonDeserializer).createConsumer();
+        embeddedKafkaBroker.consumeFromAllEmbeddedTopics(consumer);
+    }
+
+    @AfterEach
+    void tearDown() {
+        consumer.close();
+    }
 
     @Test
     @DisplayName("User controller CRUD endpoints integration test")
@@ -39,6 +84,9 @@ public class UserControllerTest {
         ResultActions registerSuccessResultAction = mockMvc.perform(MockMvcRequestBuilders.post("/users").contentType(APPLICATION_JSON_VALUE)
                         .content(saveUserDtoJsonValid))
                 .andExpect(MockMvcResultMatchers.status().is(CREATED.value()));
+
+        ConsumerRecords<String, UserDto> records = KafkaTestUtils.getRecords(consumer);
+        assertThat(records.count()).isEqualTo(1);
 
 
         // 2. User wants to register with the same email and phone | expected status code 209

--- a/USER_SERVICE/src/test/java/pl/dk/user_service/user/UserServiceImplTest.java
+++ b/USER_SERVICE/src/test/java/pl/dk/user_service/user/UserServiceImplTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import pl.dk.user_service.exception.UserConstraintException;
 import pl.dk.user_service.exception.UserNotFoundException;
+import pl.dk.user_service.notification.NotificationService;
 import pl.dk.user_service.user.dto.SaveUserDto;
 import pl.dk.user_service.user.dto.UserDto;
 import pl.dk.user_service.user.repositoryDto.EmailPhoneDto;
@@ -31,6 +32,8 @@ class UserServiceImplTest {
 
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private NotificationService notificationService;
     private AutoCloseable autoCloseable;
     private ObjectMapper objectMapper;
     private UserService underTest;
@@ -50,7 +53,7 @@ class UserServiceImplTest {
     void setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this);
         objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-        underTest = new UserServiceImpl(userRepository, objectMapper);
+        underTest = new UserServiceImpl(userRepository, objectMapper, notificationService);
 
         userId = UUID.randomUUID().toString();
         email = "john.doe@test.pl";
@@ -92,6 +95,7 @@ class UserServiceImplTest {
         // Given
         when(userRepository.findByEmailOrPhone(email, phone)).thenReturn(Optional.empty());
         when(userRepository.save(any(User.class))).thenReturn(user);
+        doNothing().when(notificationService).sendToRegistrationTopic(any(UserDto.class));
 
         // When
         UserDto result = underTest.registerUser(saveUserDto);


### PR DESCRIPTION
### Pull Request Description

#### Summary
This pull request introduces Kafka integration for user registration events within the `USER_SERVICE`. It includes the necessary configurations, services, and test updates to enable seamless event-driven communication.

---

#### Changes Overview
1. **Docker Compose**
   - Added `docker-compose.yml` to set up a Kafka cluster with:
     - 1 Zookeeper instance
     - 3 Kafka brokers

2. **Dependencies**
   - Added `spring-kafka` and `spring-kafka-test` dependencies in `pom.xml`.
   - Added `spring-boot-docker-compose` dependency for runtime support.

3. **Kafka Configuration**
   - Introduced `KafkaConfig.java` for topic creation (`user-service-registration-events` with 3 partitions and replicas).
   - Added `KafkaConstants.java` for centralized Kafka constants.

4. **Notification Service**
   - Created `NotificationService` interface and its Kafka implementation `NotificationServiceKafkaImpl`.
   - Added `sendToRegistrationTopic` method for publishing user registration events to the Kafka topic.

5. **User Service Integration**
   - Updated `UserServiceImpl` to notify the `NotificationService` after a user is successfully registered.

6. **YAML Configurations**
   - Updated `application-dev.yml` and `application.yml` to include Kafka producer configurations.

7. **Testing**
   - **Integration Tests:**
     - Updated `UserControllerTest` to include Kafka assertions.
   - **Unit Tests:**
     - Added mocking and assertions for `NotificationService` in `UserServiceImplTest`.
