### PR TITLE
feat(accounts-service): Add Kafka consumer and producer for TransferE…

### DIFF
--- a/ACCOUNTS_SERVICE/pom.xml
+++ b/ACCOUNTS_SERVICE/pom.xml
@@ -83,6 +83,15 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-circuitbreaker-resilience4j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/account/AccountService.java
+++ b/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/account/AccountService.java
@@ -5,7 +5,7 @@ import pl.dk.accounts_service.account.dtos.CreateAccountDto;
 
 import java.math.BigDecimal;
 
-interface AccountService {
+public interface AccountService {
 
     AccountDto createAccount(CreateAccountDto createAccountDto);
     AccountDto getAccountById(String accountId);

--- a/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/KafkaConfig.java
+++ b/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/KafkaConfig.java
@@ -1,0 +1,21 @@
+package pl.dk.accounts_service.kafka;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+import static pl.dk.accounts_service.kafka.KafkaConstants.*;
+
+@Configuration
+class KafkaConfig {
+
+    @Bean
+    public NewTopic registrationEvents() {
+        return TopicBuilder.name(PROCESS_TRANSFER_EVENT)
+                .partitions(3)
+                .replicas(3)
+                .build();
+    }
+
+}

--- a/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/KafkaConstants.java
+++ b/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/KafkaConstants.java
@@ -1,0 +1,8 @@
+package pl.dk.accounts_service.kafka;
+
+public class KafkaConstants {
+
+    public static final String CREATE_TRANSFER_EVENT = "transfer-service-create-transfer-event";
+    public static final String PROCESS_TRANSFER_EVENT = "accounts-service-process-transfer-event";
+    public static final String ACCOUNT_DTO_TRUSTED_PACKAGE = "pl.dk.transfer_service.transfer.dtos";
+}

--- a/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/consumer/TransferEventConsumer.java
+++ b/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/consumer/TransferEventConsumer.java
@@ -1,0 +1,49 @@
+package pl.dk.accounts_service.kafka.consumer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import pl.dk.accounts_service.account.AccountService;
+import pl.dk.accounts_service.account.dtos.AccountDto;
+import pl.dk.accounts_service.exception.AccountNotExistsException;
+import pl.dk.accounts_service.kafka.consumer.dtos.TransferEvent;
+import pl.dk.accounts_service.kafka.producer.TransferProducerService;
+
+import java.math.BigDecimal;
+
+import static pl.dk.accounts_service.kafka.KafkaConstants.CREATE_TRANSFER_EVENT;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+class TransferEventConsumer {
+
+    private final TransferProducerService transferProducerService;
+    private final AccountService accountService;
+
+    @KafkaListener(topics = {CREATE_TRANSFER_EVENT},
+            properties = "spring.json.value.default.type=pl.dk.accounts_service.kafka.consumer.dtos.TransferEvent")
+    @Transactional
+    public void onMessage(ConsumerRecord<String, TransferEvent> consumerRecord) {
+        TransferEvent transferEvent = consumerRecord.value();
+        log.info("ConsumerRecord: {}", consumerRecord);
+        BigDecimal amount = transferEvent.amount();
+        try {
+            updateAccountBalance(transferEvent.senderAccountNumber(), amount.negate());
+            updateAccountBalance(transferEvent.recipientAccountNumber(), amount);
+            transferProducerService.processTransferSuccessfully(transferEvent);
+        } catch (AccountNotExistsException ex) {
+            transferProducerService.processTransferFailure(transferEvent);
+        }
+    }
+
+    private void updateAccountBalance(String accountNumber, BigDecimal amount) {
+        log.info("Updating sender account balance, account number {}", accountNumber);
+        AccountDto accountDto = accountService.updateAccountBalance(accountNumber, amount);
+        log.info("Updated account balance, account number {}, current account balance {}", accountNumber, accountDto);
+    }
+
+}

--- a/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/consumer/dtos/TransferEvent.java
+++ b/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/consumer/dtos/TransferEvent.java
@@ -1,0 +1,17 @@
+package pl.dk.accounts_service.kafka.consumer.dtos;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Builder
+public record TransferEvent(
+        String transferId,
+        String senderAccountNumber,
+        String recipientAccountNumber,
+        BigDecimal amount,
+        String currencyType,
+        LocalDateTime transferDate,
+        String transferStatus) {
+}

--- a/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/producer/TransferProducerService.java
+++ b/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/producer/TransferProducerService.java
@@ -1,0 +1,9 @@
+package pl.dk.accounts_service.kafka.producer;
+
+import pl.dk.accounts_service.kafka.consumer.dtos.TransferEvent;
+
+public interface TransferProducerService {
+
+    void processTransferSuccessfully(TransferEvent transferEvent);
+    void processTransferFailure(TransferEvent transferEvent);
+}

--- a/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/producer/TransferProducerServiceImpl.java
+++ b/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/producer/TransferProducerServiceImpl.java
@@ -1,0 +1,35 @@
+package pl.dk.accounts_service.kafka.producer;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import pl.dk.accounts_service.kafka.consumer.dtos.TransferEvent;
+import pl.dk.accounts_service.kafka.producer.dtos.ResponseTransferEvent;
+
+import static pl.dk.accounts_service.kafka.KafkaConstants.*;
+
+@Service
+@RequiredArgsConstructor
+class TransferProducerServiceImpl implements TransferProducerService {
+
+    private final KafkaTemplate<String, ResponseTransferEvent> kafkaTemplate;
+
+    @Override
+    public void processTransferSuccessfully(TransferEvent transferEvent) {
+        ResponseTransferEvent producerResponse = buildResponse(transferEvent, TransferStatus.COMPLETED);
+        kafkaTemplate.send(PROCESS_TRANSFER_EVENT, transferEvent.transferId(), producerResponse);
+    }
+
+    @Override
+    public void processTransferFailure(TransferEvent transferEvent) {
+        ResponseTransferEvent producerResponse = buildResponse(transferEvent, TransferStatus.FAILED);
+        kafkaTemplate.send(PROCESS_TRANSFER_EVENT, transferEvent.transferId(), producerResponse);
+    }
+
+    private ResponseTransferEvent buildResponse(TransferEvent transferEvent, TransferStatus transferStatus) {
+        return ResponseTransferEvent.builder()
+                .transferId(transferEvent.transferId())
+                .transferStatus(transferStatus.name())
+                .build();
+    }
+}

--- a/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/producer/TransferStatus.java
+++ b/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/producer/TransferStatus.java
@@ -1,0 +1,8 @@
+package pl.dk.accounts_service.kafka.producer;
+
+enum TransferStatus {
+    PENDING,
+    COMPLETED,
+    FAILED,
+    CANCELLED
+}

--- a/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/producer/dtos/ResponseTransferEvent.java
+++ b/ACCOUNTS_SERVICE/src/main/java/pl/dk/accounts_service/kafka/producer/dtos/ResponseTransferEvent.java
@@ -1,0 +1,11 @@
+package pl.dk.accounts_service.kafka.producer.dtos;
+
+import lombok.Builder;
+
+
+@Builder
+public record ResponseTransferEvent(
+        String transferId,
+        String transferStatus
+) {
+}

--- a/ACCOUNTS_SERVICE/src/main/resources/application-dev.yml
+++ b/ACCOUNTS_SERVICE/src/main/resources/application-dev.yml
@@ -17,6 +17,25 @@ spring:
       circuitbreaker:
         enabled: true
 
+  kafka:
+    consumer:
+      bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.use.type.headers: false
+      group-id: transfer-events-listener-group
+    listener:
+      concurrency: 3
+
+    producer:
+      bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        retries: 3
+        retry-backoff-ms: 5000
+
   datasource:
     url: jdbc:h2:mem:test
 

--- a/ACCOUNTS_SERVICE/src/test/java/pl/dk/accounts_service/kafka/consumer/TransferEventConsumerTest.java
+++ b/ACCOUNTS_SERVICE/src/test/java/pl/dk/accounts_service/kafka/consumer/TransferEventConsumerTest.java
@@ -1,0 +1,108 @@
+package pl.dk.accounts_service.kafka.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.MessageListenerContainer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.ContainerTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import pl.dk.accounts_service.account.AccountService;
+import pl.dk.accounts_service.account.dtos.AccountDto;
+import pl.dk.accounts_service.exception.AccountNotExistsException;
+import pl.dk.accounts_service.kafka.consumer.dtos.TransferEvent;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.*;
+import static pl.dk.accounts_service.kafka.KafkaConstants.CREATE_TRANSFER_EVENT;
+
+@SpringBootTest
+@EmbeddedKafka(topics = CREATE_TRANSFER_EVENT)
+@DirtiesContext
+@TestPropertySource(properties = {"spring.kafka.producer.bootstrap-servers=${spring.embedded.kafka.brokers}",
+        "spring.kafka.consumer.bootstrap-servers=${spring.embedded.kafka.brokers}"})
+class TransferEventConsumerTest {
+
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
+
+    @Autowired
+    private KafkaTemplate<String, TransferEvent> kafkaTemplate;
+
+    @Autowired
+    private KafkaListenerEndpointRegistry endpointRegistry;
+
+    @MockitoSpyBean
+    private TransferEventConsumer transferEventConsumer;
+
+    @MockitoBean
+    private AccountService accountService;
+
+    TransferEvent transferEvent;
+
+    @BeforeEach
+    void setUp() {
+        for (MessageListenerContainer messageListenerContainer : endpointRegistry.getListenerContainers()) {
+            ContainerTestUtils.waitForAssignment(messageListenerContainer, embeddedKafkaBroker.getPartitionsPerTopic());
+        }
+        transferEvent = TransferEvent.builder()
+                .transferId("3c869968-782c-4625-ba8f-b20e8c793468")
+                .senderAccountNumber("36310206164628513592651084")
+                .recipientAccountNumber("01112962489695456055040725")
+                .amount(BigDecimal.valueOf(1500.50))
+                .currencyType("PLN")
+                .transferDate(LocalDateTime.parse("2024-12-19T14:30:00"))
+                .transferStatus("COMPLETED")
+                .build();
+    }
+
+    @Test
+    @DisplayName("It should consume TransferEvent successfully")
+    void itShouldConsumeTransferEventSuccessfully() throws InterruptedException {
+        // Given
+        AccountService accountService = mock(AccountService.class);
+        when(accountService.updateAccountBalance(anyString(), any(BigDecimal.class)))
+                .thenReturn(AccountDto.builder().build());
+        kafkaTemplate.send(CREATE_TRANSFER_EVENT, transferEvent);
+
+        // When
+        CountDownLatch latch = new CountDownLatch(1);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
+        // Then
+        verify(transferEventConsumer, times(1))
+                .onMessage(any(ConsumerRecord.class));
+    }
+
+    @Test
+    @DisplayName("It should failure with consume TransferEvent")
+    void itShouldFailureWithConsumeTransferEvent() throws InterruptedException {
+        // Given
+        when(accountService.updateAccountBalance(anyString(), any(BigDecimal.class)))
+                .thenThrow(new AccountNotExistsException("Account with id: %s not exists"));
+        kafkaTemplate.send(CREATE_TRANSFER_EVENT, transferEvent);
+
+        // When
+        CountDownLatch latch = new CountDownLatch(1);
+        latch.await(500, TimeUnit.MILLISECONDS);
+
+        // Then
+        verify(transferEventConsumer, times(1))
+                .onMessage(isA(ConsumerRecord.class));
+    }
+
+}


### PR DESCRIPTION
### Kafka Integration for Accounts Service

This pull request introduces Kafka integration to the Accounts Service. The main purpose is to enable asynchronous communication between services for processing transfer events.

---

#### Changes Overview:

1. **Kafka Configuration**:
    - Added `KafkaConfig` to define topics.
    - Added `KafkaConstants` to hold Kafka-related constants.

2. **Kafka Consumer**:
    - Introduced `TransferEventConsumer` for consuming transfer events.
    - Added handling logic to update account balances and process transfer events.

3. **Kafka Producer**:
    - Implemented `TransferProducerService` and its implementation to publish transfer status updates.

4. **DTOs**:
    - Created `TransferEvent` (consumer DTO) and `ResponseTransferEvent` (producer DTO).

5. **Enums**:
    - Added `TransferStatus` to define transfer states.

6. **Testing**:
    - Introduced `TransferEventConsumerTest` with embedded Kafka to validate consumer behavior.

7. **Configuration**:
    - Updated `application-dev.yml` to include Kafka producer and consumer properties.

