### PR TITLE
feat(card-service): add Postgres and Docker support

### DIFF
--- a/card-service/compose.yml
+++ b/card-service/compose.yml
@@ -1,0 +1,14 @@
+services:
+  carddb:
+    image: 'postgres:latest'
+    container_name: carddb
+    restart: always
+    environment:
+      POSTGRES_DB: carddb
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      PGDATA: /pg-data
+    ports:
+      - '5433:5432'
+    volumes:
+      - ./pg-data:/pg-data

--- a/card-service/pom.xml
+++ b/card-service/pom.xml
@@ -95,6 +95,23 @@
             <version>4.2.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+            <version>11.2.0</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-docker-compose</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/card-service/src/main/resources/application-dev.yml
+++ b/card-service/src/main/resources/application-dev.yml
@@ -1,41 +1,17 @@
-server:
-  port: 8086
-  error:
-    include-message: always
-    include-stacktrace: never
-
 spring:
   config:
     activate:
       on-profile: dev
-  output:
-    ansi:
-      enabled: ALWAYS
 
   datasource:
     url: jdbc:h2:mem:test
 
-  jpa:
-    hibernate:
-      ddl-auto: validate
-    show-sql: true
-    properties:
-      hibernate:
-        highlight_sql: true
-        format_sql: true
-      open-in-view: false
-    open-in-view: false
+  devtools:
+    livereload:
+      enabled: true
 
-  flyway:
-    locations:
-      - classpath:db/migration
-    clean-disabled: false
-    enabled: true
-    execute-in-transaction: true
-logging:
-  level:
-    pl:
-      dk:
-        exchange_service: TRACE
-logging.level.org.hibernate.orm.jdbc.bind: TRACE
-logging.level.org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+  docker:
+    compose:
+      enabled: false
+
+

--- a/card-service/src/main/resources/application-prod.yml
+++ b/card-service/src/main/resources/application-prod.yml
@@ -1,0 +1,23 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  datasource:
+    url: jdbc:postgresql://localhost:5433/carddb
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+  docker:
+    compose:
+      enabled: true
+      stop:
+        command: down
+      skip:
+        in-tests: true
+      file: card-service/compose.yml
+
+  devtools:
+    livereload:
+      enabled: false

--- a/card-service/src/main/resources/application.yml
+++ b/card-service/src/main/resources/application.yml
@@ -1,10 +1,3 @@
-spring:
-  application:
-    name: card-service
-
-  profiles:
-    active: dev
-
 eureka:
   instance:
     prefer-ip-address: true
@@ -14,5 +7,56 @@ eureka:
     service-url:
       defaultZone: http://localhost:8000/eureka
 
+server:
+  port: 8086
+  error:
+    include-message: always
+    include-stacktrace: never
+
+spring:
+  application:
+    name: card-service
+
+  output:
+    ansi:
+      enabled: ALWAYS
+
+  profiles:
+    active: prod
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: true
+    properties:
+      hibernate:
+        highlight_sql: true
+        format_sql: true
+      open-in-view: false
+    open-in-view: false
+
+  flyway:
+    locations:
+      - classpath:db/migration
+    clean-disabled: false
+    enabled: true
+    execute-in-transaction: true
+
+  devtools:
+    livereload:
+      enabled: false
+
+  docker:
+    compose:
+      enabled: false
+
 scheduler:
   cards-active: 0 0 0 * * *
+
+logging:
+  level:
+    pl:
+      dk:
+        cardservice: TRACE
+logging.level.org.hibernate.orm.jdbc.bind: TRACE
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder: TRACE


### PR DESCRIPTION
### Summary
This pull request introduces multiple enhancements and changes to the `card-service`. The primary focus of this update is to integrate PostgreSQL as the database, enable Flyway for database migrations, and introduce Docker Compose support for local development.

### Changes
1. **Database Integration**
   - Updated `application.yml` and `application-prod.yml` to support PostgreSQL with environment variables.
   - Added Flyway dependency for database migration.
   
2. **Docker Compose Support**
   - Introduced `compose.yml` to run a PostgreSQL container for `card-service`.
   - Configured the `docker.compose` section in Spring Boot settings to enable automatic service startup.

3. **Profile Management**
   - Refactored `application.yml` to default to `prod` profile.
   - Introduced `application-dev.yml` for development and `application-prod.yml` for production configurations.

### Notes
This update ensures better database management, easier local setup, and improved maintainability for `card-service`.

