### PR TITLE
feat(exchange-service): add Docker and PostgreSQL support

### DIFF
--- a/exchange-service/compose.yml
+++ b/exchange-service/compose.yml
@@ -1,0 +1,14 @@
+services:
+  exchangedb:
+    image: 'postgres:latest'
+    container_name: exchangedb
+    restart: always
+    environment:
+      POSTGRES_DB: exchangedb
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      PGDATA: /pg-data
+    ports:
+      - '5434:5432'
+    volumes:
+      - ./pg-data:/pg-data

--- a/exchange-service/pom.xml
+++ b/exchange-service/pom.xml
@@ -105,6 +105,23 @@
             <artifactId>spring-aspects</artifactId>
             <version>6.1.15</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-docker-compose</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+            <version>11.2.0</version>
+            <scope>runtime</scope>
+        </dependency>
+
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/exchange-service/src/main/resources/application-dev.yml
+++ b/exchange-service/src/main/resources/application-dev.yml
@@ -1,40 +1,19 @@
-server:
-  port: 8085
-  error:
-    include-message: always
-    include-stacktrace: never
 
 spring:
   config:
     activate:
       on-profile: dev
-  output:
-    ansi:
-      enabled: ALWAYS
 
   datasource:
     url: jdbc:h2:mem:test
 
-  jpa:
-    hibernate:
-      ddl-auto: validate
-    show-sql: true
-    properties:
-      hibernate:
-        highlight_sql: true
-        format_sql: true
-      open-in-view: false
+  docker:
+    compose:
+      enabled: false
 
-  flyway:
-    locations:
-      - classpath:db/migration
-    clean-disabled: false
-    enabled: true
-    execute-in-transaction: true
-logging:
-  level:
-    pl:
-      dk:
-        exchange_service: TRACE
-logging.level.org.hibernate.orm.jdbc.bind: TRACE
-logging.level.org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+  devtools:
+    livereload:
+      enabled: true
+    add-properties: true
+
+

--- a/exchange-service/src/main/resources/application-prod.yml
+++ b/exchange-service/src/main/resources/application-prod.yml
@@ -1,0 +1,23 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  datasource:
+    url: jdbc:postgres://localhost:5434/exchangedb
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
+
+  docker:
+    compose:
+      enabled: true
+      stop:
+        command: down
+      skip:
+        in-tests: true
+      file: exchange-service/compose.yml
+
+  devtools:
+    livereload:
+      enabled: false
+    add-properties: false

--- a/exchange-service/src/main/resources/application.yml
+++ b/exchange-service/src/main/resources/application.yml
@@ -1,14 +1,50 @@
+server:
+  port: 8085
+  error:
+    include-message: always
+    include-stacktrace: never
+
 spring:
   application:
     name: exchange-service
 
+  output:
+    ansi:
+      enabled: ALWAYS
+
   profiles:
-    active: dev
+    active: prod
 
   cloud:
     openfeign:
       okhttp:
         enabled: true
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: true
+    properties:
+      hibernate:
+        highlight_sql: true
+        format_sql: true
+      open-in-view: false
+
+  flyway:
+    locations:
+      - classpath:db/migration
+    clean-disabled: false
+    enabled: true
+    execute-in-transaction: true
+
+  docker:
+    compose:
+      enabled: false
+
+  devtools:
+    livereload:
+      enabled: false
+    add-properties: false
 
 eureka:
   instance:
@@ -21,3 +57,11 @@ eureka:
 
 scheduler:
   update-currencies: 0 0 * * * *
+
+logging:
+  level:
+    pl:
+      dk:
+        exchange_service: TRACE
+logging.level.org.hibernate.orm.jdbc.bind: TRACE
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder: TRACE


### PR DESCRIPTION
### Summary
This PR introduces several enhancements and modifications to the `exchange-service` including the addition of Docker Compose support, database configuration changes.

### Changes Implemented
1. **Docker Compose Integration:**
   - Added `compose.yml` to configure a PostgreSQL database for `exchange-service`.
   - Enabled Docker Compose support in `application-prod.yml`.
   
2. **Database Configuration Updates:**
   - Switched from H2 to PostgreSQL for production.
   - Configured Flyway for database migrations.
   - Updated `application-prod.yml` to use PostgreSQL connection details.

4. **Profile and Environment Updates:**
   - Defined separate configurations for `dev` and `prod` environments.
   - Updated `application.yml` to support both profiles.

### Files Modified
- `exchange-service/compose.yml` (New)
- `exchange-service/pom.xml`
- `exchange-service/src/main/resources/application-dev.yml`
- `exchange-service/src/main/resources/application-prod.yml`
- `exchange-service/src/main/resources/application.yml`

### Additional Notes
- Ensure that environment variables (`POSTGRES_USER` and `POSTGRES_PASSWORD`) are set before running the service in production.