### PR TITLE
feat(transfer-service): add Docker Compose and Postgres support

### DIFF
--- a/transfer-service/compose.yml
+++ b/transfer-service/compose.yml
@@ -1,0 +1,15 @@
+services:
+  transferdb:
+    image: 'postgres:latest'
+    container_name: transferdb
+    restart: always
+    environment:
+      POSTGRES_DB: transferdb
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      PGDATA: /pg-data
+    ports:
+      - '5437:5432'
+    volumes:
+      - ./pg-data:/pg-data
+

--- a/transfer-service/pom.xml
+++ b/transfer-service/pom.xml
@@ -92,6 +92,22 @@
 			<artifactId>spring-kafka-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-docker-compose</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-database-postgresql</artifactId>
+			<version>11.2.0</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/transfer-service/src/main/resources/application-dev.yml
+++ b/transfer-service/src/main/resources/application-dev.yml
@@ -1,65 +1,11 @@
-server:
-  port: 8083
-  error:
-    include-message: always
-    include-stacktrace: never
-
 spring:
   config:
     activate:
       on-profile: dev
-  output:
-    ansi:
-      enabled: ALWAYS
 
   datasource:
     url: jdbc:h2:mem:test
 
-  kafka:
-    producer:
-      bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-      properties:
-        retries: 3
-        retry-backoff-ms: 5000
-    consumer:
-      bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      properties:
-        retries: 3
-        spring.json.use.type.headers: false
-      group-id: transfer-events-listener-group
-
-  jpa:
-    hibernate:
-      ddl-auto: validate
-    show-sql: true
-    properties:
-      hibernate:
-        highlight_sql: true
-        format_sql: true
-      open-in-view: false
-
-  flyway:
-    locations:
-      - classpath:db/migration
-    clean-disabled: false
-    enabled: true
-    execute-in-transaction: true
-
-logging:
-  level:
-    pl:
-      dk:
-        transfer_service: TRACe
-
-resilience4j:
-  circuitbreaker:
-    configs:
-      default:
-        sliding-window-size: 5
-        failure-rate-threshold: 50
-        wait-duration-in-open-state: 10000
-        permitted-number-of-calls-in-half-open-state: 2
+  docker:
+    compose:
+      enabled: false

--- a/transfer-service/src/main/resources/application-prod.yml
+++ b/transfer-service/src/main/resources/application-prod.yml
@@ -1,0 +1,23 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  datasource:
+    url: jdbc:postgresql://localhost:5437/transferdb
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
+
+  docker:
+    compose:
+      enabled: true
+      stop:
+        command: down
+      skip:
+        in-tests: true
+      file: transfer-service/compose.yml
+
+  devtools:
+    livereload:
+      enabled: false
+    add-properties: false

--- a/transfer-service/src/main/resources/application.yml
+++ b/transfer-service/src/main/resources/application.yml
@@ -1,10 +1,3 @@
-spring:
-  application:
-    name: transfer-service
-
-  profiles:
-    active: dev
-
 eureka:
   instance:
     prefer-ip-address: true
@@ -14,7 +7,78 @@ eureka:
     service-url:
       defaultZone: http://localhost:8000/eureka
 
+server:
+  port: 8083
+  error:
+    include-message: always
+    include-stacktrace: never
+
+spring:
+  application:
+    name: transfer-service
+
+  output:
+    ansi:
+      enabled: ALWAYS
+
+  profiles:
+    active: prod
+
+  kafka:
+    producer:
+      bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        retries: 3
+        retry-backoff-ms: 5000
+    consumer:
+      bootstrap-servers: localhost:9092,localhost:9093,localhost:9094
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        retries: 3
+        spring.json.use.type.headers: false
+      group-id: transfer-events-listener-group
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: true
+    properties:
+      hibernate:
+        highlight_sql: true
+        format_sql: true
+    open-in-view: false
+
+  flyway:
+    locations:
+      - classpath:db/migration
+    clean-disabled: false
+    enabled: true
+    execute-in-transaction: true
+
+  docker:
+    compose:
+      enabled: false
+
 scheduler:
   transfer: 0 0 6 * * ?
 
+resilience4j:
+  circuitbreaker:
+    configs:
+      default:
+        sliding-window-size: 5
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 10000
+        permitted-number-of-calls-in-half-open-state: 2
+
+logging:
+  level:
+    pl:
+      dk:
+        transfer_service: TRACe
+logging.level.org.hibernate.orm.jdbc.bind: TRACE
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder: TRACE
 


### PR DESCRIPTION
## **Description:**

This PR introduces several changes and additions to the `transfer-service`, focusing on Docker Compose integration, PostgreSQL configuration, and environment-specific settings. Below is a summary of the key changes:

### Changes in `transfer-service`:
1. **compose.yml**:
   - Added a new Docker Compose configuration for setting up a PostgreSQL database for the transfer service. The database is configured with environment variables for user credentials and data persistence.

2. **pom.xml**:
   - Added dependencies for `spring-boot-docker-compose`, `postgresql`, and `flyway-database-postgresql` to support Docker Compose and PostgreSQL integration.

3. **application-dev.yml**:
   - Simplified the development configuration by removing redundant settings and focusing on essential configurations for the development environment, such as H2 in-memory database and Kafka settings.

4. **application-prod.yml**:
   - Introduced a new production configuration file with settings for PostgreSQL, Docker Compose, and other production-specific properties. This includes the database connection details and Docker Compose settings.

5. **application.yml**:
   - Consolidated and updated the main configuration file to include both development and production profiles, along with Kafka, JPA, Flyway, and resilience4j configurations. The active profile is set to `prod` by default.

### Summary:
This PR enhances the configuration management for the `transfer-service` by introducing Docker Compose support, refining environment-specific configurations, and ensuring proper database and Kafka integration. These changes aim to improve the maintainability, scalability, and deployment flexibility of the service.